### PR TITLE
Add open graph meta properties & set jeykll metadata to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ Icon
 # Files that might appear on external disk
 .Spotlight-V100
 .Trashes
+
+.jekyll-metadata

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,6 +6,14 @@
     <meta name="description" content="{{ site.description }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 
+    <!-- Meta infos for social networks -->
+    <meta property=”og:title” content="BPoCiT Study Group"/>
+    <meta property=”og:type” content="website"/>
+    <meta property=”og:url” content="https://bpocit.github.io/website/"/>
+    <meta property=”og:image” content="https://bpocit.github.io/website/img/bg-header-coding-v2.jpg"/>
+    <meta property=”og:description” content="A study group for Black and People of Color to learn coding, having fun time together and ask questions without fear and rush"/>
+
+
     <!-- Custom CSS & Bootstrap Core CSS - Uses Bootswatch Flatly Theme: http://bootswatch.com/flatly/ -->
     <link rel="stylesheet" href="{{ "/style.css" | prepend: site.baseurl }}">
     <link href='./js/fullcalendar/dist/fullcalendar.css' rel='stylesheet' />


### PR DESCRIPTION
This PR adds open graph meta properties to the `head.html` for social networks.

Related issue: #24 